### PR TITLE
WAL-54870 - OXID 6.10: Compatibility

### DIFF
--- a/Application/Controller/Admin/Transaction.php
+++ b/Application/Controller/Admin/Transaction.php
@@ -15,6 +15,7 @@ use Monolog\Logger;
 use Wallee\Sdk\Model\RefundState;
 use Wallee\Sdk\Model\TransactionCompletionState;
 use Wallee\Sdk\Model\TransactionVoidState;
+use Wle\Wallee\Core\Exception\OptimisticLockingException;
 use Wle\Wallee\Core\Service\CompletionService;
 use Wle\Wallee\Core\Service\RefundService;
 use Wle\Wallee\Core\Service\VoidService;
@@ -57,6 +58,9 @@ class Transaction extends \OxidEsales\Eshop\Application\Controller\Admin\AdminDe
             } else {
                 throw new \Exception(WalleeModule::instance()->translate('No order selected'));
             }
+        } catch (OptimisticLockingException $e){
+            $this->_aViewData['wle_wallee_enabled'] = true;
+            return $this->_sThisTemplate;
         } catch (\Exception $e) {
             $this->_aViewData['wle_error'] = $e->getMessage();
             return 'wleWalleeError.tpl';

--- a/Application/Controller/Webhook.php
+++ b/Application/Controller/Webhook.php
@@ -49,6 +49,9 @@ class Webhook extends \OxidEsales\Eshop\Core\Controller\BaseController
         } catch (\Exception $e) {
             header("HTTP/1.1 500 Internal Server Error");
             echo($e->getMessage());
+            $message = "Ups, something was wrong. {$e->getMessage()} - {$e->getTraceAsString()}.";
+            WalleeModule::log(Logger::ERROR, $message);
+            WalleeModule::getUtilsView()->addErrorToDisplay($message);
             exit();
         }
         header("HTTP/1.1 200 OK");

--- a/Application/Model/Transaction.php
+++ b/Application/Model/Transaction.php
@@ -38,7 +38,7 @@ use Wle\Wallee\Core\Exception\OptimisticLockingException;
  * Transaction model.
  */
 class Transaction extends \OxidEsales\Eshop\Core\Model\BaseModel {
-    const OPTIMISTIC_RETRIES = 5;
+    const OPTIMISTIC_RETRIES = 10;
     private $_sTableName = 'wleWallee_transaction';
 	private $version = false;
 	protected $dbVersion = null;
@@ -604,6 +604,7 @@ class Transaction extends \OxidEsales\Eshop\Core\Model\BaseModel {
             $affected = \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->execute($updateQuery);
 
             if ($index === self::OPTIMISTIC_RETRIES) {
+                $affected = $index;
                 break;
             }
             $index++;

--- a/Application/Model/Transaction.php
+++ b/Application/Model/Transaction.php
@@ -38,8 +38,7 @@ use Wle\Wallee\Core\Exception\OptimisticLockingException;
  * Transaction model.
  */
 class Transaction extends \OxidEsales\Eshop\Core\Model\BaseModel {
-    const OPTIMISTIC_RETRIES = 10;
-    private $_sTableName = 'wleWallee_transaction';
+	private $_sTableName = 'wleWallee_transaction';
 	private $version = false;
 	protected $dbVersion = null;
 	/**
@@ -592,28 +591,17 @@ class Transaction extends \OxidEsales\Eshop\Core\Model\BaseModel {
 		if (!$dbVersion) {
 			$dbVersion = 0;
 		}
+		$updateQuery = "update {$coreTableName} set " . $this->_getUpdateFields() . " , wleversion=wleversion + 1 " .
+				 " where {$coreTableName}.oxid = " . $database->quote($this->getId()) .
+				 " and {$coreTableName}.wleversion = {$dbVersion}";
+		WalleeModule::log(Logger::DEBUG, "Updating  transaction with query [$updateQuery]");
 
-        $index = 0;
-        do {
-            $updateQuery = "update {$coreTableName} set " . $this->_getUpdateFields() . " , wleversion=wleversion + 1 " .
-                " where {$coreTableName}.oxid = " . $database->quote($this->getId()) .
-                " and {$coreTableName}.wleversion = {$dbVersion}";
-            WalleeModule::log(Logger::DEBUG, "Updating  transaction with query [$updateQuery]");
+		$this->beforeUpdate();
+		$affected = \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->execute($updateQuery);
 
-            $this->beforeUpdate();
-            $affected = \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->execute($updateQuery);
-
-            if ($index === self::OPTIMISTIC_RETRIES) {
-                $affected = $index;
-                break;
-            }
-            $index++;
-
-        } while ($affected === 0);
-
-        if ($affected === 0) {
-            throw new OptimisticLockingException($this->getId(), $this->_sTableName, $updateQuery);
-        }
+		if ($affected === 0) {
+			throw new OptimisticLockingException($this->getId(), $this->_sTableName, $updateQuery);
+		}
 
 		return true;
 	}

--- a/Core/Webhook/AbstractOrderRelated.php
+++ b/Core/Webhook/AbstractOrderRelated.php
@@ -35,7 +35,7 @@ abstract class AbstractOrderRelated extends AbstractWebhook
         }
         for($i = 0; $i <= self::OPTIMISTIC_RETRIES; $i++) {
 	        try {
-	        	\OxidEsales\Eshop\Core\DatabaseProvider::getDb()->startTransaction();
+	        	//\OxidEsales\Eshop\Core\DatabaseProvider::getDb()->startTransaction();
 	            $entity = $this->loadEntity($request);
 	            $orderId = $this->getOrderId($entity);
 	            $order = $this->loadOrder($orderId);
@@ -51,7 +51,7 @@ abstract class AbstractOrderRelated extends AbstractWebhook
 		            }
 	            }
 	            
-	            \OxidEsales\Eshop\Core\DatabaseProvider::getDb()->commitTransaction();
+	            //\OxidEsales\Eshop\Core\DatabaseProvider::getDb()->commitTransaction();
 	        }catch(OptimisticLockingException $e){
 	        	WalleeModule::log(Logger::WARNING, "Optimistic locking query: " . $e->getQueryString());
 	        	WalleeModule::rollback();

--- a/Core/Webhook/AbstractOrderRelated.php
+++ b/Core/Webhook/AbstractOrderRelated.php
@@ -19,8 +19,9 @@ use Wle\Wallee\Core\Exception\OptimisticLockingException;
  */
 abstract class AbstractOrderRelated extends AbstractWebhook
 {
-	const NO_ORDER = 1;
-	const OPTIMISTIC_RETRIES = 6;
+    const NO_ORDER = 1;
+    const OPTIMISTIC_RETRIES = 3;
+    const SECONDS_TO_WAIT = 1;
 
     /**
      * Processes the received order related webhook request.
@@ -57,7 +58,7 @@ abstract class AbstractOrderRelated extends AbstractWebhook
 	        	if($i === self::OPTIMISTIC_RETRIES) {
 	        		throw $e;
 	        	}
-	        	sleep(2);
+	        	sleep(self::SECONDS_TO_WAIT);
 	        }
 	        catch (\Exception $e) {
 	            WalleeModule::log(Logger::ERROR, $e->getMessage() . ' - ' . $e->getTraceAsString());

--- a/Core/Webhook/AbstractOrderRelated.php
+++ b/Core/Webhook/AbstractOrderRelated.php
@@ -57,7 +57,7 @@ abstract class AbstractOrderRelated extends AbstractWebhook
 	        	if($i === self::OPTIMISTIC_RETRIES) {
 	        		throw $e;
 	        	}
-	        	sleep(1);
+	        	sleep(2);
 	        }
 	        catch (\Exception $e) {
 	            WalleeModule::log(Logger::ERROR, $e->getMessage() . ' - ' . $e->getTraceAsString());

--- a/Core/Webhook/Transaction.php
+++ b/Core/Webhook/Transaction.php
@@ -3,6 +3,7 @@
  * Wallee OXID
  *
  * This OXID module enables to process payments with Wallee (https://www.wallee.com/).
+ * @version 2
  *
  * @package Whitelabelshortcut\Wallee
  * @author customweb GmbH (http://www.customweb.com/)

--- a/Core/Webhook/Transaction.php
+++ b/Core/Webhook/Transaction.php
@@ -57,14 +57,25 @@ class Transaction extends AbstractOrderRelated
      */
     protected function processOrderRelatedInner(\OxidEsales\Eshop\Application\Model\Order $order, $entity)
     {
+        $finalStates = [
+            TransactionState::FAILED,
+            TransactionState::VOIDED,
+            TransactionState::DECLINE,
+            TransactionState::FULFILL
+        ];
+
+        if (in_array($entity->getState(), $finalStates)) {
+            return false;
+        }
+
         if ($entity->getState() !== $order->getWalleeTransaction()->getState()) {
             $cancel = false;
             switch ($entity->getState()) {
                 case TransactionState::AUTHORIZED:
                 case TransactionState::FULFILL:
                 case TransactionState::COMPLETED:
-                    $oldState = $order->getFieldData('oxtransstatus');
                     $order->setWalleeState($entity->getState());
+                    $oldState = $order->getFieldData('oxtransstatus');
                     if (!WalleeModule::isAuthorizedState($oldState)) {
                         $order->WalleeAuthorize();
                     }


### PR DESCRIPTION
Closes WAL-54870

**TESTING INSTRUCTIONS**

Go to the Oxid Showcase →  

Make at least two payments buying anything, and you need to pay with MasterCard (this credit card has the payment deferred to test Void, Complete and Refunds payments).

Go to the admin side → https://oxid-6.showcase-wallee.com/adminusername: admin@admin.compassword: admin123

- First test: VOID PAYMENTS. 

Go to the order list, click on Administer Orders → Orders and select the last order. Now click on the wallee Transaction tab; in this point, you can see the Transaction Information, so click on the void button. You must see a message like “Successfully created and sent void job“.

- Second test: COMPLETE AND REFUNDS PAYMENTS.

Go to the order list, click on Administer Orders → Orders and select another order. Now click on the wallee Transaction tab; in this point, you can see the Transaction Information, so click on the void button. You must see a message like “Successfully created and sent complete job“. Then you can use the same order to make a refund, so click on the refund button, and on the next screen click on the full button and after that click on the refund button. You must see a message like “Successfully created and sent refund job“.

- Last test: Verify the webhook invocations.

The last thing, you have to log in on the wallee portal and select the Oxid 6 Showcase space, it’ll be faster if you go to this link after the log in → https://app-wallee.com/s/26614/webhook/invocation/list. Now you need to confirm that you have several invocations on the webhook. 

If everything is ok, give your approval. Thanks in advance.